### PR TITLE
Fix Spotify media controls

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -253,7 +253,7 @@ jobs:
       project-name: tuna
     steps:
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.0
+        uses: microsoft/setup-msbuild@v1.0.2
       - name: Checkout
         uses: actions/checkout@v2
         with:

--- a/src/query/spotify_source.cpp
+++ b/src/query/spotify_source.cpp
@@ -476,14 +476,13 @@ long execute_command(const char* auth_token, const char* url, std::string& respo
     CURL* curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_URL, url);
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, util::write_callback);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+
     if (put) {
         curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "");
-		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, util::write_callback);
-		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
     } else {
-        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, util::write_callback);
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
         curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
         curl_easy_setopt(curl, CURLOPT_HEADERDATA, &response_header);
     }

--- a/src/query/spotify_source.cpp
+++ b/src/query/spotify_source.cpp
@@ -467,11 +467,15 @@ bool spotify_source::new_token(QString& log)
 long execute_command(const char* auth_token, const char* url, std::string& response_header,
     QJsonDocument& response_json, bool put)
 {
-    std::string response;
-    std::string header = "Authorization: Bearer ";
     long http_code = -1;
+    std::string response;
+
+    std::string header = "Authorization: Bearer ";
     header.append(auth_token);
+
     auto* list = curl_slist_append(nullptr, header.c_str());
+    list = curl_slist_append(list, "Content-Length: 0");
+    list = curl_slist_append(list, "Content-Type: application/json");
 
     CURL* curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_URL, url);
@@ -481,7 +485,6 @@ long execute_command(const char* auth_token, const char* url, std::string& respo
 
     if (put) {
         curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "");
     } else {
         curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_callback);
         curl_easy_setopt(curl, CURLOPT_HEADERDATA, &response_header);

--- a/src/query/spotify_source.cpp
+++ b/src/query/spotify_source.cpp
@@ -474,8 +474,6 @@ long execute_command(const char* auth_token, const char* url, std::string& respo
     header.append(auth_token);
 
     auto* list = curl_slist_append(nullptr, header.c_str());
-    list = curl_slist_append(list, "Content-Length: 0");
-    list = curl_slist_append(list, "Content-Type: application/json");
 
     CURL* curl = curl_easy_init();
     curl_easy_setopt(curl, CURLOPT_URL, url);
@@ -487,6 +485,7 @@ long execute_command(const char* auth_token, const char* url, std::string& respo
 
     if (custom_request_type != nullptr) {
         curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, custom_request_type);
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "{}");
     }
 
     if (!response_header.empty())

--- a/src/query/spotify_source.cpp
+++ b/src/query/spotify_source.cpp
@@ -260,7 +260,7 @@ bool spotify_source::execute_capability(capability c)
 
     switch (c) {
     case CAP_PLAY_PAUSE:
-        if (m_current.state()) {
+        if (!m_current.state()) {
             [[clang::fallthrough]];
         case CAP_STOP_SONG:
             http_code = execute_command(qt_to_utf8(m_token), PLAYER_PAUSE_URL, header, response, true);

--- a/src/query/spotify_source.cpp
+++ b/src/query/spotify_source.cpp
@@ -260,7 +260,7 @@ bool spotify_source::execute_capability(capability c)
 
     switch (c) {
     case CAP_PLAY_PAUSE:
-        if (!m_current.state()) {
+        if (m_current.state() == state_playing) {
             [[clang::fallthrough]];
         case CAP_STOP_SONG:
             http_code = execute_command(qt_to_utf8(m_token), PLAYER_PAUSE_URL, header, response, "PUT");

--- a/src/query/spotify_source.cpp
+++ b/src/query/spotify_source.cpp
@@ -478,6 +478,7 @@ long execute_command(const char* auth_token, const char* url, std::string& respo
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
     if (put) {
         curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
+        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "");
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, util::write_callback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
     } else {

--- a/src/query/spotify_source.cpp
+++ b/src/query/spotify_source.cpp
@@ -478,7 +478,6 @@ long execute_command(const char* auth_token, const char* url, std::string& respo
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, list);
     if (put) {
         curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "{}");
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, util::write_callback);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
     } else {


### PR DESCRIPTION
So finally, it was only the pause / play that were reversed. You probably should use an enum instead of a boolean for `m_current.state()` (because `true` means paused and you should execute the play command, it gets really confusing).

Second thing is that next / previous are POST and not PUT requests according to [the Spotify Player API reference](https://developer.spotify.com/documentation/web-api/reference/player/).

Finally, I updated a workflow item because of this (shown in your build actions, because obviously I decided to work on this on November 17th 🤣) : 
![image](https://user-images.githubusercontent.com/8122888/99346175-4dc59f80-2894-11eb-82f7-bbc7228c76ae.png)

