### PR TITLE
mpd_source: clear current song info when refreshing

### DIFF
--- a/src/query/mpd_source.cpp
+++ b/src/query/mpd_source.cpp
@@ -109,6 +109,7 @@ void mpd_source::refresh()
     if (!connection)
         return;
     begin_refresh();
+    m_current.clear();
 
     status = mpd_run_status(connection);
     mpd_song = mpd_run_current_song(connection);


### PR DESCRIPTION
Following the bug I mentioned [here](https://github.com/univrsal/tuna/issues/103#issuecomment-753540832), I did a fix.

It may not be really clean, I don't know if you meant to remove that line. @univrsal if you have any suggestion, please let me know.