### PR TITLE
Add Pretzel support

### DIFF
--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -221,7 +221,7 @@
                     post({ cover_url, title, artists, status, progress, duration, album_url });
                 }
             }
-        }, 500);
+        }, refresh_rate_ms);
 
     }
 

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -1,0 +1,172 @@
+// ==UserScript==
+// @name         Tuna browser script
+// @namespace    univrsal
+// @version      1.0.6
+// @description  Get song information from web players, based on NowSniper by Kıraç Armağan Önal
+// @author       univrsal
+// @match        *://open.spotify.com/*
+// @match        *://soundcloud.com/*
+// @match        *://music.yandex.com/*
+// @match        *://music.yandex.ru/*
+// @match        *://www.deezer.com/*
+// @grant        unsafeWindow
+// @license      GPLv2
+// ==/UserScript==
+
+(function() {
+    'use strict';
+    // Configuration
+    var port = 1608;
+    var refresh_rate_ms = 500;
+    var cooldown_ms = 10000;
+
+    // Tuna isn't running we sleep, because every failed request will log into the console
+    // so we don't want to spam it
+    var failure_count = 0;
+    var cooldown = 0;
+
+    function post(data){
+        var url = 'http://localhost:' + port + '/';
+        var xhr = new XMLHttpRequest();
+        xhr.open('POST', url);
+
+        xhr.setRequestHeader('Accept', 'application/json');
+        xhr.setRequestHeader('Content-Type', 'application/json');
+        xhr.setRequestHeader('Access-Control-Allow-Headers', '*');
+        xhr.setRequestHeader('Access-Control-Allow-Origin', '*');
+
+        xhr.onreadystatechange = function () {
+            if (xhr.readyState === 4) {
+                if (xhr.status !== 200) {
+                    failure_count++;
+                }
+            }
+        };
+        xhr.send(JSON.stringify({data,hostname:window.location.hostname,date:Date.now()}));
+    }
+
+    // Safely query something, and perform operations on it
+    function query(target, fun, alt = null) {
+        var element = document.querySelector(target);
+        if (element !== null) {
+            return fun(element);
+        }
+        return alt;
+    }
+
+    function timestamp_to_ms(ts) {
+        var splits = ts.split(':');
+        if (splits.length == 2) {
+            return splits[0] * 60 * 1000 + splits[1] * 1000;
+        } else if (splits.length == 3) {
+            return splits[0] * 60 * 60 * 1000 + splits[1] * 60 * 1000 + splits[0] * 1000;
+        }
+        return 0;
+    }
+
+    function StartFunction() {
+        setInterval(()=>{
+            if (failure_count > 3) {
+                console.log('Failed to connect multiple times, waiting a few seconds');
+                cooldown = cooldown_ms;
+                failure_count = 0;
+            }
+
+            if (cooldown > 0) {
+                cooldown -= refresh_rate_ms;
+                return;
+            }
+
+            let hostname = window.location.hostname;
+
+            // TODO: maybe add more?
+            if (hostname == 'soundcloud.com') {
+                let status = query('.playControl', e => e.classList.contains('playing') ? "playing" : "stopped", 'unknown');
+                let cover_url = query('.playbackSoundBadge span.sc-artwork', e => e.style.backgroundImage.slice(5, -2).replace('t50x50','t500x500'));
+                let title = query('.playbackSoundBadge__titleLink', e => e.title);
+                let artists = [ query('.playbackSoundBadge__lightLink', e => e.title) ];
+                let progress = query('.playbackTimeline__timePassed span:nth-child(2)', e => timestamp_to_ms(e.textContent));
+                let duration = query('.playbackTimeline__duration span:nth-child(2)', e => timestamp_to_ms(e.textContent));
+                let album_url = query('.playbackSoundBadge__titleLink', e => e.href);
+
+                if (title !== null) {
+                    post({ cover_url, title, artists, status, progress, duration, album_url });
+                }
+            } else if (hostname == 'open.spotify.com') {
+                let status = query('.player-controls [data-testid="control-button-pause"]', e => !!e ? 'playing' : 'stopped', 'unknown');
+                let cover_url = query('[data-testid="CoverSlotExpanded__container"] .cover-art-image', e => e.style.backgroundImage.slice(5, -2));
+                let title = query('[data-testid="nowplaying-track-link"]', e => e.textContent);
+                let artists = query('span[draggable] a[href*="artist"]', e => Array.from(e));
+                let progress = query('.playback-bar .playback-bar__progress-time', e => timestamp_to_ms(e[0].textContent));
+                let duration = query('.playback-bar .playback-bar__progress-time', e => timestamp_to_ms(e[1].textContent));
+                let album_url = query('[data-testid="nowplaying-track-link"]', e => e.href);
+
+                if (title !== null) {
+                    post({ cover_url, title, artists, status, progress, duration, album_url });
+                }
+            } else if (hostname == 'music.yandex.ru') {
+                // Yandex music support by MjKey
+                let status = query('.player-controls__btn_play', e => e.classList.contains('player-controls__btn_pause') ? "playing" : "stopped", 'unknown');
+                let cover_url = query('.entity-cover__image', e => e.style.backgroundImage.slice(5, -2).replace('50x50','200x200'));
+                let title = query('.track__title', e => e.title);
+                let artists = [ query('.track__artists', e => e.textContent) ];
+                let progress = query('.progress__left', e => timestamp_to_ms(e.textContent));
+                let duration = query('.progress__right', e => timestamp_to_ms(e.textContent));
+                let album_url = query('.track-cover a', e => e.title);
+
+                if (title !== null) {
+                    post({ cover_url, title, artists, status, progress, duration, album_url });
+                }
+            } else if (hostname == 'www.deezer.com') {
+                let status = query('.player-controls', e => {
+                    let buttons = e.getElementsByTagName('button');
+                    if (buttons && buttons.length > 1) {
+                        if (buttons[1].getAttribute('aria-label') === 'Pause') {
+                            return "playing";
+                        } else {
+                            return "stopped";
+                        }
+                    }
+                    return "unknown";
+                });
+
+                let cover_url = query('button.queuelist.is-available', e => {
+                    let img = e.getElementsByTagName('img');
+                    if (img.length > 0) {
+                        let src = img[0].src; // https://e-cdns-images.dzcdn.net/images/cover/c4217689cc86e3e6a289162239424dc3/28x28-000000-80-0-0.jpg
+                        return src.replace('28x28', '512x512');
+                    }
+                    return null;
+                });
+
+                let title = query('.marquee-content', e => {
+                    let links = e.getElementsByClassName('track-link');
+                    if (links.length > 0) {
+                        return links[0].textContent;
+                    }
+                    return null;
+                });
+                let artists = query('.marquee-content', e => {
+                    let links = e.getElementsByClassName('track-link');
+                    let artists = [];
+                    if (links.length > 1) {
+                        for (var i = 1; i < links.length; i++) {
+                            artists.push(links[i].textContent);
+                        }
+                        return artists;
+                    }
+                    return null;
+                });
+
+                let duration = query('.slider-counter-max', e => timestamp_to_ms(e.textContent));
+                let progress = query('.slider-counter-current', e => timestamp_to_ms(e.textContent));
+                if (title !== null) {
+                    post({ cover_url, title, artists, status, progress, duration });
+                }
+            }
+        }, 500);
+
+    }
+
+    StartFunction();
+})();


### PR DESCRIPTION
This is adding support for [Pretzel.rocks](https://www.pretzel.rocks).
Although they do have a Desktop Application with a filewriting feature, it is Windows only, so this is helpful mainly for Linux and Mac users.

Split into 3 commits:
1. The original file currently on Greasyfork

2. The actual support for Pretzel
It is unfortunately a little hacky, but I currently see no other way of implementing it. There is no change in states anywhere on the page that I could select for the play status, and neither is there an `<audio>` element I could query the status of. The only thing changing is the icon on the Play/Pause button. The way this is done is not a class-swap, but simply replacing the SVG within. So the workaround is selecting part of the `<path>` SVG element that is unique to both icons.
I hope the class names I used for selecting are not changing anytime soon, but again, I couldn't find anything else unique.

3. A small change that makes the `setInterval()` actually use the configured refresh rate, previously it was only being used for the cooldown reduction.

---

One note/question:
Is the `album_url` supposed to contain only the album name, or the actual url? SoundCloud and Spotify both use the actual URL, while Yandex only sends the title, and Deezer doesn't send anything at all. I'm not entirely sure what the point of writing the URL would be though considering this is probably just going on an overlay?