### PR TITLE
Various Widget fixups and a bit of re-write

### DIFF
--- a/data/widget.html
+++ b/data/widget.html
@@ -173,12 +173,12 @@
                 if (artists != last_artist) {
                     var artistLine = '';
                     if (artists != '')
-                        artistsLine += "by " + artists + " ";
+                        artistsLine += "<i>by</i> " + artists + " ";
 
                     // sometimes there is an album with no artist, we can still allow that
                     if (data['album'] != undefined &&
                         data['album'] != artists) // Some singles have the artist as the album, which looks strange with the other subtitle
-                        artistsLine += "on " + data['album'];
+                        artistsLine += "<i>on</i> " + data['album'];
 
                     // use &nbsp; in case we have neither artist nor album
                     // space is considered empty element, &nbsp; is not

--- a/data/widget.html
+++ b/data/widget.html
@@ -98,8 +98,8 @@
                 <img src="placeholder.png" id="cover">
             </div>
             <div class="info">
-                <p id="title">Title</p>
-                <p id="artist">Artist</p>
+                <p id="title">&nbsp;</p>
+                <p id="artist">&nbsp;</p>
                 <div id="timeline">
                     <div>
                         <p id="length">0:00</p>
@@ -155,7 +155,9 @@
                         artists += ', ';
                 }
 
-                document.getElementById('title').innerText = data['title'];
+                if (data['title'] != last_title)
+                    document.getElementById('title').innerText = data['title'];
+
                 if (data['cover_url'] == undefined ||
                     data['cover_url'] == '') {
                     document.getElementById('cover').src = "placeholder.png";
@@ -168,12 +170,20 @@
                     last_cover = data['cover_url'];
                 }
 
-                if (artists == '')
-                    document.getElementById('artist').innerHTML = '&nbsp;'; // space is considered empty element, &nbsp; is not
-                else if (artists === data['album'] || data['album'] === undefined) // Some singles have the artist as the album, which looks strange with the other subtitle
-                    document.getElementById('artist').innerHTML = 'by ' + artists;
-                else
-                    document.getElementById('artist').innerHTML = 'by ' + artists + ' on ' + data['album']
+                if (artists != last_artist) {
+                    var artistLine = '';
+                    if (artists != '')
+                        artistsLine += "by " + artists + " ";
+
+                    // sometimes there is an album with no artist, we can still allow that
+                    if (data['album'] != undefined &&
+                        data['album'] != artists) // Some singles have the artist as the album, which looks strange with the other subtitle
+                        artistsLine += "on " + data['album'];
+
+                    // use &nbsp; in case we have neither artist nor album
+                    // space is considered empty element, &nbsp; is not
+                    artistLine == '' ? document.getElementById('artist').innerHTML = "&nbsp;" : document.getElementById('artist').innerHTML = artistLine
+                }
 
                 var length = data['duration'];
                 var progress = data['progress'];

--- a/data/widget.html
+++ b/data/widget.html
@@ -32,7 +32,7 @@
             height: 100%;
             float: left;
         }
-        
+
         .image-box img {
             position: relative;
             z-index: -1;
@@ -50,7 +50,7 @@
             margin: 0px;
             padding-bottom: 2px;
         }
-        
+
         #artist {
             font-size: large;
         }
@@ -114,7 +114,7 @@
             </div>
         </div>
     </body>
-    
+
     <script>
         var last_cover = '';
         var last_artist = '';
@@ -130,7 +130,7 @@
 
             if (secs < 10)
                 secs = '0' + secs;
-            
+
             if (hrs > 0) {
                 if (mins < 10)
                     mins = '0' + mins;
@@ -145,7 +145,7 @@
             .then(data => {
                 // data now contains the json object with song metadata
 
-                
+
                 // artist list
                 var artists = '';
                 var array = data['artists'];
@@ -169,7 +169,7 @@
                     document.getElementById('artist').innerText = 'by ' + artists;
                 else
                     document.getElementById('artist').innerText = 'by ' + artists + ' from ' + data['album']
-                
+
                 var length = data['duration'];
                 var progress = data['progress'];
                 document.getElementById('progress').style.width = (progress / length) * 100 + '%';
@@ -177,7 +177,7 @@
                 // Timestamps
                 document.getElementById('length').innerText = format_ms(length);
                 document.getElementById('time-passed').innerText = format_ms(progress);
-                
+
                 last_artist = artists;
                 last_title = data['title'];
             })
@@ -185,7 +185,7 @@
                 // Do nothing
             });
         }
-        
+
         setInterval(fetch_data, 500);
     </script>
 </html>

--- a/data/widget.html
+++ b/data/widget.html
@@ -148,7 +148,7 @@
 
                 // artist list
                 var artists = '';
-                var array = data['artists'];
+                var array = data['artists'] || []; // in some cases no artist is known/submitted
                 for (var i = 0; i < array.length; i++) {
                     artists += array[i];
                     if (i < array.length - 1)
@@ -156,7 +156,10 @@
                 }
 
                 document.getElementById('title').innerText = data['title'];
-                if (data['cover_url'] !== last_cover || // Refresh only if meta data suggests that the cover changed
+                if (data['cover_url'] == undefined ||
+                    data['cover_url'] == '') {
+                    document.getElementById('cover').src = "placeholder.png";
+                } else if (data['cover_url'] !== last_cover || // Refresh only if meta data suggests that the cover changed
                     (data['title'] !== last_title &&    // When using MPD the path is always the cover path configured in tuna
                     artists !== last_artist))           // which means it won't change so we check against other data
                 {
@@ -165,10 +168,12 @@
                     last_cover = data['cover_url'];
                 }
 
-                if (artists === data['album'] || data['album'] === undefined) // Some singles have the artist as the album, which looks strange with the other subtitle
-                    document.getElementById('artist').innerText = 'by ' + artists;
+                if (artists == '')
+                    document.getElementById('artist').innerHTML = '&nbsp;'; // space is considered empty element, &nbsp; is not
+                else if (artists === data['album'] || data['album'] === undefined) // Some singles have the artist as the album, which looks strange with the other subtitle
+                    document.getElementById('artist').innerHTML = 'by ' + artists;
                 else
-                    document.getElementById('artist').innerText = 'by ' + artists + ' from ' + data['album']
+                    document.getElementById('artist').innerHTML = 'by ' + artists + ' on ' + data['album']
 
                 var length = data['duration'];
                 var progress = data['progress'];


### PR DESCRIPTION
This is split up into 4 commits, so they can be fixed up or reverted individually (I also only thought of some thing after already having commited :P )

In short:
1. Fixed whitespace (automatic through .editorconfig)
2. Fix up widget breaking under certain conditions 
3. Re-write how the artist is constructed so we don't have to repeat a whole bunch of stuff with each edge case. The entire string is then inserted at the same time
4. Minor stylisation for "by" and "on" (previously "from") to differentiate them from the actual titles

See commit messages for more details.

Note: Some of these cases were only tested manually as there is an outstanding issue with no artist/album being returned for browser-sources, which will be filed independently. As I don't use any of the other possible sources I can't really test this very much. Everything should work fine, but I wanted to mention it.