### PR TITLE
Browser/Pretzel: Fix artist not being sent correctly

### DIFF
--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -200,7 +200,7 @@
                 let artists = query('div.kzpiRD', e => {
                     let elements = e.getElementsByTagName('a');
                     if (elements.length > 0) {
-                        return elements[0].textContent;
+                        return [ elements[0].textContent ];
                     }
                     return null;
                 });


### PR DESCRIPTION
Tuna expects the artists to be an array, previously we only sent a
string. This results in no artist being available for file-write and
widget-JSON.

See also univrsal/tuna#156