### PR TITLE
Widget: Fix Widget not displaying artist/progress

### DIFF
--- a/data/widget.html
+++ b/data/widget.html
@@ -173,12 +173,12 @@
                 if (artists != last_artist) {
                     var artistLine = '';
                     if (artists != '')
-                        artistsLine += "<i>by</i> " + artists + " ";
+                        artistLine += "<i>by</i> " + artists + " ";
 
                     // sometimes there is an album with no artist, we can still allow that
                     if (data['album'] != undefined &&
                         data['album'] != artists) // Some singles have the artist as the album, which looks strange with the other subtitle
-                        artistsLine += "<i>on</i> " + data['album'];
+                        artistLine += "<i>on</i> " + data['album'];
 
                     // use &nbsp; in case we have neither artist nor album
                     // space is considered empty element, &nbsp; is not


### PR DESCRIPTION
Fixes 2 typos that caused the artist to never be displayed and the
progress never updating because the code was never executed due to
incorrect variable assignments.

---

I'm sorry, no idea how this slipped by during testing for #155 :/

Because `artistsLine` was non existent before, these were never executed:
https://github.com/univrsal/tuna/blob/7e4c2a2985f0f955803e962db3adfb496ccfd221/data/widget.html#L176
https://github.com/univrsal/tuna/blob/7e4c2a2985f0f955803e962db3adfb496ccfd221/data/widget.html#L181

For some reason this also halted execution for anything following that, to be quite honest I have no idea why (been out of development for a while :eyes: ).