### PR TITLE
Plex Web and support for more

### DIFF
--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -297,7 +297,7 @@
                     "playing":"playing",
                     "paused":"stopped"
                 }
-                let status = mediaSessionStatesToTunaStates[navigator.mediaSession.playbackState] || "unknown"]
+                let status = mediaSessionStatesToTunaStates[navigator.mediaSession.playbackState] || "unknown";
                 // let cover_url = not supported yet!
                 let title = navigator.mediaSession.metadata.title;
                 let artists = [navigator.mediaSession.metadata.artist];

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -11,6 +11,7 @@
 // @match        *://www.deezer.com/*
 // @match        *://play.pretzel.rocks/*
 // @match        *://*.youtube.com/*
+// @match        *://app.plex.tv/*
 // @grant        unsafeWindow
 // @license      GPLv2
 // ==/UserScript==

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -289,6 +289,27 @@
                 if (title !== null) {
                     post({ cover_url, title, artists, status, progress, duration, album_url, album });
                 }
+            } else if (hostname === "app.plex.tv") {
+                // simple plex web support by javaarchive
+                const mediaSessionStatesToTunaStates = {
+                    "none": "unknown",
+                    "playing":"playing,
+                    "paused":"stopped"
+                }
+                let status = mediaSessionStatesToTunaStates[navigator.mediaSession.playbackState] || "unknown"]
+                // let cover_url = not supported yet!
+                let title = navigator.mediaSession.metadata.title;
+                let artists = [navigator.mediaSession.metadata.artist];
+                let progress = document.getElementsByTagName("audio")[0].currentTime * 1000;
+                let duration = document.getElementsByTagName("audio")[0].duration * 1000;
+                let artworks = navigator.mediaSession.metadata.artwork;
+                let album = navigator.mediaSession.metadata.album;
+                let album_url = artworks[artworks.length - 1].src;
+                let cover_url = album_url; // For now. 
+                
+                if (title !== null) {
+                    post({ cover_url, title, artists, status, progress, duration, album, album_url });
+                }
             }
         }, refresh_rate_ms);
 

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tuna browser script
 // @namespace    univrsal
-// @version      1.0.12
+// @version      1.0.13
 // @description  Get song information from web players, based on NowSniper by Kıraç Armağan Önal
 // @author       univrsal
 // @match        *://open.spotify.com/*

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -305,8 +305,8 @@
                     let artists = [navigator.mediaSession.metadata.artist];
                     
                     let mediaElem = document.getElementsByTagName("audio")[0]; // add || document.getElementsByTagName("video")[0] to support sites like yt music where video includes audio
-                    let progress = mediaElem.currentTime * 1000;
-                    let duration = mediaElem.duration * 1000;
+                    let progress = Math.floor(mediaElem.currentTime) * 1000;
+                    let duration = Math.floor(mediaElem.duration) * 1000;
                     
                     let artworks = navigator.mediaSession.metadata.artwork;
                     let album = navigator.mediaSession.metadata.album;

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -299,17 +299,19 @@
                 }
                 let status = mediaSessionStatesToTunaStates[navigator.mediaSession.playbackState] || "unknown";
                 // let cover_url = not supported yet!
-                let title = navigator.mediaSession.metadata.title;
-                let artists = [navigator.mediaSession.metadata.artist];
-                let progress = document.getElementsByTagName("audio")[0].currentTime * 1000;
-                let duration = document.getElementsByTagName("audio")[0].duration * 1000;
-                let artworks = navigator.mediaSession.metadata.artwork;
-                let album = navigator.mediaSession.metadata.album;
-                let album_url = artworks[artworks.length - 1].src;
-                let cover_url = album_url; // For now. 
-                
-                if (title !== null) {
-                    post({ cover_url, title, artists, status, progress, duration, album, album_url });
+                if(navigator.mediaSession.metadata){
+                    let title = navigator.mediaSession.metadata.title;
+                    let artists = [navigator.mediaSession.metadata.artist];
+                    let progress = document.getElementsByTagName("audio")[0].currentTime * 1000;
+                    let duration = document.getElementsByTagName("audio")[0].duration * 1000;
+                    let artworks = navigator.mediaSession.metadata.artwork;
+                    let album = navigator.mediaSession.metadata.album;
+                    let album_url = artworks[artworks.length - 1].src;
+                    let cover_url = album_url; // For now. 
+
+                    if (title !== null) {
+                        post({ cover_url, title, artists, status, progress, duration, album, album_url });
+                    }
                 }
             }
         }, refresh_rate_ms);

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -292,18 +292,22 @@
                 }
             } else if (hostname === "app.plex.tv") {
                 // simple plex web support by javaarchive
+                // this is kind of more "universal" as it reads data from the browser media session api
+                // see https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API for more info
                 const mediaSessionStatesToTunaStates = {
                     "none": "unknown",
                     "playing":"playing",
                     "paused":"stopped"
                 }
                 let status = mediaSessionStatesToTunaStates[navigator.mediaSession.playbackState] || "unknown";
-                // let cover_url = not supported yet!
                 if(navigator.mediaSession.metadata){
                     let title = navigator.mediaSession.metadata.title;
                     let artists = [navigator.mediaSession.metadata.artist];
-                    let progress = document.getElementsByTagName("audio")[0].currentTime * 1000;
-                    let duration = document.getElementsByTagName("audio")[0].duration * 1000;
+                    
+                    let mediaElem = document.getElementsByTagName("audio")[0]; // add || document.getElementsByTagName("video")[0] to support sites like yt music where video includes audio
+                    let progress = mediaElem.currentTime * 1000;
+                    let duration = mediaElem.duration * 1000;
+                    
                     let artworks = navigator.mediaSession.metadata.artwork;
                     let album = navigator.mediaSession.metadata.album;
                     let album_url = artworks[artworks.length - 1].src;

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -294,7 +294,7 @@
                 // simple plex web support by javaarchive
                 const mediaSessionStatesToTunaStates = {
                     "none": "unknown",
-                    "playing":"playing,
+                    "playing":"playing",
                     "paused":"stopped"
                 }
                 let status = mediaSessionStatesToTunaStates[navigator.mediaSession.playbackState] || "unknown"]


### PR DESCRIPTION
Plex had a lack of usable selectors. So I did some research and came across the following browser api
https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API
which seems to be a more "universal" way to support sites that play music. 

