### PR TITLE
treewide: replace deprecated qAsConst with std::as_const()

### DIFF
--- a/src/gui/tuna_gui.cpp
+++ b/src/gui/tuna_gui.cpp
@@ -184,7 +184,7 @@ void tuna_gui::toggleShowHide()
             ui->tbl_outputs->removeRow(row);
         row = 0; /* Load rows */
         ui->tbl_outputs->setRowCount(config::outputs.size());
-        for (const auto& entry : qAsConst(config::outputs)) {
+        for (const auto& entry : std::as_const(config::outputs)) {
             ui->tbl_outputs->setItem(row, 0, new QTableWidgetItem(entry.log_mode ? "Yes" : "No"));
             ui->tbl_outputs->setItem(row, 1, new QTableWidgetItem(entry.format));
             ui->tbl_outputs->setItem(row, 2, new QTableWidgetItem(entry.path));
@@ -206,7 +206,7 @@ void tuna_gui::add_source(const QString& display, const QString& id, source_widg
 
 void tuna_gui::refresh()
 {
-    for (auto widget : qAsConst(m_source_widgets))
+    for (auto widget : std::as_const(m_source_widgets))
         widget->tick();
 }
 

--- a/src/query/music_source.cpp
+++ b/src/query/music_source.cpp
@@ -77,7 +77,7 @@ void init()
     const auto s = config_get_string(obs_frontend_get_global_config(), CFG_REGION, CFG_SELECTED_SOURCE);
     auto i = 0;
     auto selected_source = -1;
-    for (const auto& src : qAsConst(music_sources::instances)) {
+    for (const auto& src : std::as_const(music_sources::instances)) {
         if (strcmp(src->id(), s) == 0) {
             selected_source = i;
             break;
@@ -120,7 +120,7 @@ void select(const char* id)
     if (selected)
         selected->reset_info();
     int i = 0;
-    for (const auto& src : qAsConst(instances)) {
+    for (const auto& src : std::as_const(instances)) {
         if (strcmp(src->id(), id) == 0) {
             selected_index = i;
             break;
@@ -134,7 +134,7 @@ void select(const char* id)
 
 void set_gui_values()
 {
-    for (const auto& src : qAsConst(instances))
+    for (const auto& src : std::as_const(instances))
         src->set_gui_values();
 }
 

--- a/src/query/music_source.hpp
+++ b/src/query/music_source.hpp
@@ -128,7 +128,7 @@ extern std::shared_ptr<music_source> selected_source();
 template<class T>
 std::shared_ptr<T> get(const char* id)
 {
-    for (const auto& src : qAsConst(instances)) {
+    for (const auto& src : std::as_const(instances)) {
         if (strcmp(src->id(), id) == 0) {
             return std::dynamic_pointer_cast<T>(src);
         }

--- a/src/query/spotify_source.cpp
+++ b/src/query/spotify_source.cpp
@@ -244,7 +244,7 @@ void spotify_source::parse_track_json(const QJsonValue& response)
 
     QStringList tmp;
     /* Get All artists */
-    for (const auto& artist : qAsConst(artists))
+    for (const auto& artist : std::as_const(artists))
         tmp.append(artist.toObject()["name"].toString());
     m_current.set(meta::ARTIST, tmp);
 

--- a/src/util/config.cpp
+++ b/src/util/config.cpp
@@ -182,7 +182,7 @@ void load_outputs()
         if (doc.isArray())
             array = doc.array();
 
-        for (const auto& val : qAsConst(array)) {
+        for (const auto& val : std::as_const(array)) {
             QJsonObject obj = val.toObject();
             output tmp;
             tmp.format = legacy_convert(obj[JSON_FORMAT_ID].toString());
@@ -206,7 +206,7 @@ void load_outputs()
 void save_outputs()
 {
     QJsonArray output_array;
-    for (const auto& o : qAsConst(outputs)) {
+    for (const auto& o : std::as_const(outputs)) {
         QJsonObject output;
         output[JSON_FORMAT_ID] = o.format;
         output[JSON_OUTPUT_PATH_ID] = QDir::toNativeSeparators(o.path);


### PR DESCRIPTION
Reference: https://github.com/qt/qtbase/blob/v6.6.0/src/corelib/global/qttypetraits.h#L32