### PR TITLE
feat: support data:image on mpris:artUrl

### DIFF
--- a/src/query/mpris_source.cpp
+++ b/src/query/mpris_source.cpp
@@ -199,8 +199,8 @@ DBusHandlerResult mpris_source::handle_dbus(DBusMessage* message)
 static inline QString correct_art_url(const char* url)
 {
     auto str = utf8_to_qt(url);
-    // Don't encode if it's a file or http(s) url
-    if (str.startsWith("file://") || str.startsWith("http://") || str.startsWith("https://")) {
+    // Don't encode if it's a file, data:image or http(s) url
+    if (str.startsWith("data:image/") || str.startsWith("file://") || str.startsWith("http://") || str.startsWith("https://")) {
         return str;
     }
     return QUrl::toPercentEncoding(utf8_to_qt(url)).replace("%2F", "/").replace("file%3A", "file:").replace("%3A", ":"); // idk why it encodes slashes

--- a/src/util/utility.cpp
+++ b/src/util/utility.cpp
@@ -155,6 +155,28 @@ bool download_cover(const QString& url)
         }
         berr("Cover file '%s' does not exist", qt_to_utf8(new_cover_path));
         return false;
+    } else if (url.startsWith("data:image/")) {
+        int comma = url.indexOf(',');
+        if (comma == -1)
+            berr("Failed to open file '%s' for writing", qt_to_utf8(output_path));
+        return false;
+
+        QByteArray base64 = url.mid(comma + 1).toUtf8();
+        QByteArray image_data = QByteArray::fromBase64(base64);
+
+        QFile current(output_path);
+        current.remove();
+        if (!current.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+            berr("Failed to open file '%s' for writing", qt_to_utf8(output_path));
+            return false;
+        }
+
+        if (current.write(image_data) != image_data.size()) {
+            berr("Failed to write all image data to '%s'", qt_to_utf8(output_path));
+            return false;
+        }
+
+        return true;
     }
 
     result = curl_download(qt_to_utf8(url), qt_to_utf8(tmp));

--- a/src/util/utility.cpp
+++ b/src/util/utility.cpp
@@ -145,21 +145,27 @@ bool download_cover(const QString& url)
         // Don't use curl for local files
         QString new_cover_path = QUrl::fromPercentEncoding(url.mid(prefix_length).toUtf8());
         QFile cover(new_cover_path);
-        if (cover.exists()) {
-            QFile current(output_path);
-            current.remove();
-            if (QFile::copy(new_cover_path, output_path))
-                return true;
+
+        if (!cover.exists()) {
+            berr("Cover file '%s' does not exist", qt_to_utf8(new_cover_path));
+            return false;
+        }
+
+        QFile current(output_path);
+        current.remove();
+
+        if (!QFile::copy(new_cover_path, output_path)) {
             berr("Couldn't copy cover file from '%s' to '%s'", qt_to_utf8(new_cover_path), qt_to_utf8(output_path));
             return false;
         }
-        berr("Cover file '%s' does not exist", qt_to_utf8(new_cover_path));
-        return false;
+
+        return true;
     } else if (url.startsWith("data:image/")) {
         int comma = url.indexOf(',');
-        if (comma == -1)
+        if (comma == -1) {
             berr("Failed to open file '%s' for writing", qt_to_utf8(output_path));
-        return false;
+            return false;
+        }
 
         QByteArray base64 = url.mid(comma + 1).toUtf8();
         QByteArray image_data = QByteArray::fromBase64(base64);
@@ -181,15 +187,22 @@ bool download_cover(const QString& url)
 
     result = curl_download(qt_to_utf8(url), qt_to_utf8(tmp));
 
+    if (!result) {
+        berr("Failed to download image from '%s'", qt_to_utf8(url));
+        return false;
+    }
+
     /* Replace cover only after download is done */
     QFile current(output_path);
     current.remove();
 
-    if (result && !QFile::rename(tmp, output_path)) {
+    if (!QFile::rename(tmp, output_path)) {
         berr("Couldn't rename temporary cover file");
-        result = false;
+        return false;
     }
-    return result;
+
+    QFile::remove(tmp);
+    return true;
 }
 
 void reset_cover()


### PR DESCRIPTION
adding support for data/image in urls, using existing config value config::cover_size so covers stop changing sizes between song source etc.., gotta adapt UI so it makes more sense but its functional
