### PR TITLE
Update lyrics.html to start after pause

### DIFF
--- a/data/lyrics.html
+++ b/data/lyrics.html
@@ -179,6 +179,8 @@
                         current_lyrics = [];
                         getLyrics(current_title, current_artists, current_album)
                     }
+                    if (data['status'] != current_status)
+                        current_status = data['status'];
                 })
                 .catch(function () {
                     // Do nothing


### PR DESCRIPTION
The lyrics thing didn't update the status field automatically which resulted into it not starting the scrolling when you unpaused after the widget was loaded whilst the song was paused