### PR TITLE
Covers: Fix deprecated taglib usage

### DIFF
--- a/src/util/cover_tag_handler.cpp
+++ b/src/util/cover_tag_handler.cpp
@@ -68,7 +68,7 @@ bool extract_ape(TagLib::APE::Tag* tag)
     const TagLib::APE::ItemListMap& listMap = tag->itemListMap();
     if (listMap.contains("COVER ART (FRONT)")) {
         const TagLib::ByteVector nullStringTerminator(1, 0);
-        TagLib::ByteVector item = listMap["COVER ART (FRONT)"].value();
+        TagLib::ByteVector item = listMap["COVER ART (FRONT)"].binaryData();
         const int pos = item.find(nullStringTerminator); // Skip the filename.
         if (pos != -1) {
             const TagLib::ByteVector& pic = item.mid(pos + 1);


### PR DESCRIPTION
`APE::Item::value()` is deprecated even in taglib 1.13.1:

https://github.com/taglib/taglib/blob/c840222a391439285478820b4477d5fa6b78d63d/taglib/ape/apeitem.h#L113-L116

The replacement function is also mentioned in the [2.0 release notes](https://github.com/taglib/taglib/releases/tag/v2.0):

> * Removed deprecated functions:
>   * APE::Item::value(): Use binaryData()

tytan has been using this in his AUR package for 2 years - hence the `Co-authored-by` - I'm just upstreaming it:
https://aur.archlinux.org/cgit/aur.git/commit/PKGBUILD?h=obs-tuna&id=70f06292744abc17b3f9b8aa568c5d790bf37049

I also built with taglib 1.13.1 as a sanity check and it compiled fine.

I also saw #205, but it isn't merged and doesn't include this anyway.

It might also be worth looking into unbundling taglib and libmpdclient alltogether, but that's outside the scope of this.

edit:
`clang-format` check is unrelated. Not sure why it doesn't find `glibc`.