### PR TITLE
Chillhop Creator Dashboard Web Browser Support

### DIFF
--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -391,8 +391,8 @@
 
                 let title = document.getElementsByClassName("p-track-title")[0].innerText; // Title
                 let artists = [document.getElementsByClassName("p-track-artist")[0].innerText]; // Artist(s)
-                let progress = document.getElementsByClassName("play-progress-at")[0].innerText; // Current Time
-                let duration = document.getElementsByClassName("play-progress-duration")[0]; // Total Time
+                let progress = timestamp_to_ms(document.getElementsByClassName("play-progress-at")[0].innerText.slice(1)); // Current Time
+                let duration = timestamp_to_ms(document.getElementsByClassName("play-progress-duration")[0].innerText.slice(1)); // Total Time
 
                 // Unfortunately, referencing the cover URL returns a 403, so we can't use it.
                 // However, including it removes the default gray question mark icon, which may look nicer on stream overlays,

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -380,14 +380,10 @@
                 }
             } else if (hostname === "chillhop.com") {
                 // Simple Chillhop support by Exopl0x
-                // Supports Chillhop Creators Dashboard, so monetize at your hearts content!
-                // Just make sure you credit Chillhop correctly:
-                // https://chillhop.notion.site/Crediting-Chillhop-as-a-Creator-a9663987fbf44a799f692a2197bf19da#5531e20c04874bb0a2b8082c65d2f4b9
-
-                let plButtonElement = document.getElementById('p-btn-play');
+                // Supports Chillhop Creators Dashboard.
 
                 let status = "unknown";
-                if (plButtonElement.classList.contains('playing')) {
+                if (document.getElementById('p-btn-play').classList.contains('playing')) {
                     status = "playing";
                 } else {
                     status = "stopped";
@@ -403,8 +399,10 @@
                 // revealing whatever's underneath the cover normally.
                 let cover = document.getElementsByClassName("player-image")[0].style.backgroundImage.slice(5, -2); // Cover
 
+                // Chillhop doesn't expose album information, so it's absent.
+                let album = ''
                 if (title !== null) {
-                    post({ cover, title, artists, status, progress, duration });
+                    post({ cover, title, artists, status, progress, duration, album });
                 }
             }
         }, refresh_rate_ms);

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -392,7 +392,7 @@
                 let title = document.getElementsByClassName("p-track-title")[0].innerText; // Title
                 let artists = [document.getElementsByClassName("p-track-artist")[0].innerText]; // Artist(s)
                 let progress = document.getElementsByClassName("play-progress-at")[0].innerText; // Current Time
-                let duration = document.getElementsByClassName("play-progress-duration")[0]; // Current Time
+                let duration = document.getElementsByClassName("play-progress-duration")[0]; // Total Time
 
                 // Unfortunately, referencing the cover URL returns a 403, so we can't use it.
                 // However, including it removes the default gray question mark icon, which may look nicer on stream overlays,

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -400,9 +400,8 @@
                 let cover = document.getElementsByClassName("player-image")[0].style.backgroundImage.slice(5, -2); // Cover
 
                 // Chillhop doesn't expose album information, so it's absent.
-                let album = ''
                 if (title !== null) {
-                    post({ cover, title, artists, status, progress, duration, album });
+                    post({ cover, title, artists, status, progress, duration });
                 }
             }
         }, refresh_rate_ms);

--- a/deps/tuna_browser.user.js
+++ b/deps/tuna_browser.user.js
@@ -12,6 +12,7 @@
 // @match        *://play.pretzel.rocks/*
 // @match        *://*.youtube.com/*
 // @match        *://app.plex.tv/*
+// @match        *://chillhop.com/*
 // @match        *://www.bilibili.com/*
 // @grant        unsafeWindow
 // @grant        GM_xmlhttpRequest
@@ -376,6 +377,34 @@
                 let album = bvid;
                 if (title) {
                     post({ cover, title, artists, status, progress, duration, album, album_url });
+                }
+            } else if (hostname === "chillhop.com") {
+                // Simple Chillhop support by Exopl0x
+                // Supports Chillhop Creators Dashboard, so monetize at your hearts content!
+                // Just make sure you credit Chillhop correctly:
+                // https://chillhop.notion.site/Crediting-Chillhop-as-a-Creator-a9663987fbf44a799f692a2197bf19da#5531e20c04874bb0a2b8082c65d2f4b9
+
+                let plButtonElement = document.getElementById('p-btn-play');
+
+                let status = "unknown";
+                if (plButtonElement.classList.contains('playing')) {
+                    status = "playing";
+                } else {
+                    status = "stopped";
+                }
+
+                let title = document.getElementsByClassName("p-track-title")[0].innerText; // Title
+                let artists = [document.getElementsByClassName("p-track-artist")[0].innerText]; // Artist(s)
+                let progress = document.getElementsByClassName("play-progress-at")[0].innerText; // Current Time
+                let duration = document.getElementsByClassName("play-progress-duration")[0]; // Current Time
+
+                // Unfortunately, referencing the cover URL returns a 403, so we can't use it.
+                // However, including it removes the default gray question mark icon, which may look nicer on stream overlays,
+                // revealing whatever's underneath the cover normally.
+                let cover = document.getElementsByClassName("player-image")[0].style.backgroundImage.slice(5, -2); // Cover
+
+                if (title !== null) {
+                    post({ cover, title, artists, status, progress, duration });
                 }
             }
         }, refresh_rate_ms);


### PR DESCRIPTION
Noticed that https://chillhop.com Creator Dashboard (Web media player inside Chillhop containing songs specifically licensed for streaming) wasn't working on tuna, so I decided to add some simple support to the tampermonkey injection script.

Note that this is my first time ever working with JS so there could be some things here and there that I missed, and this is also my first time ever contributing to any open source repo so let me know if I'm doing anything wrong or if there's anything I could do to help make your lives better when it comes to my merge.